### PR TITLE
Make fn gen_account_keys_prost public

### DIFF
--- a/filter/src/message.rs
+++ b/filter/src/message.rs
@@ -780,7 +780,7 @@ impl MessageTransaction {
         }
     }
 
-    fn gen_account_keys_prost(
+    pub fn gen_account_keys_prost(
         transaction: &SubscribeUpdateTransactionInfo,
         meta: &TransactionStatusMeta,
     ) -> Result<HashSet<Pubkey>, MessageParseError> {


### PR DESCRIPTION
This allows building custom transaction filters without code repetition by copying code from richat-filter