### PR TITLE
grpc: drain buffer + try_lock to eliminate poll_next contention

### DIFF
--- a/richat/src/grpc/server.rs
+++ b/richat/src/grpc/server.rs
@@ -42,7 +42,7 @@ use {
     solana_pubkey::Pubkey,
     std::{
         borrow::Cow,
-        collections::{HashSet, LinkedList},
+        collections::{HashSet, LinkedList, VecDeque},
         fmt,
         future::Future,
         pin::Pin,
@@ -391,12 +391,10 @@ impl GrpcServer {
             drop(state);
 
             // Wake poll_next so it can drain via try_lock.
-            // Yield briefly only when the client has buffered messages,
-            // so poll_next (on a tokio thread) can win the lock against
-            // pinned worker threads that would otherwise re-acquire instantly.
+            // No sleep needed — poll_next drains all messages into a local
+            // buffer in one lock acquisition, so contention is minimal.
             if messages_counter > 0 || has_pending {
                 client.drain_waker.wake();
-                sleep(Duration::from_millis(1));
             }
 
             if errored {
@@ -922,13 +920,17 @@ impl SubscribeClientState {
 pub struct ReceiverStream {
     client: SubscribeClient,
     finished: bool,
+    /// Local buffer — drained from shared state while holding the lock.
+    /// Subsequent poll_next calls serve from here without contention.
+    drain: VecDeque<TonicResult<Vec<u8>>>,
 }
 
 impl ReceiverStream {
-    const fn new(client: SubscribeClient) -> Self {
+    fn new(client: SubscribeClient) -> Self {
         Self {
             client,
             finished: false,
+            drain: VecDeque::new(),
         }
     }
 }
@@ -943,45 +945,60 @@ impl Drop for ReceiverStream {
 impl Stream for ReceiverStream {
     type Item = TonicResult<Vec<u8>>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.finished {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.finished {
             return Poll::Ready(None);
         }
 
-        let mut state = match self.client.state.try_lock() {
+        // Serve from local buffer first — no lock needed.
+        if let Some(item) = this.drain.pop_front() {
+            this.finished = item.is_err();
+            return Poll::Ready(Some(item));
+        }
+
+        // Local buffer empty — acquire lock and drain shared state.
+        let mut state = match this.client.state.try_lock() {
             Ok(guard) => guard,
             Err(_) => {
-                self.client.drain_waker.register(cx.waker());
-                match self.client.state.try_lock() {
+                this.client.drain_waker.register(cx.waker());
+                match this.client.state.try_lock() {
                     Ok(guard) => guard,
                     Err(_) => return Poll::Pending,
                 }
             }
         };
 
-        if let Some(item) = state.pop_message(cx) {
+        // Drain ALL messages from shared state into local buffer.
+        let x_subscription_id = Arc::clone(&state.x_subscription_id);
+
+        while let Some(item) = state.pop_message(cx) {
             let item = match item {
                 Ok((message, data)) => {
                     counter!(
                         metrics::GRPC_SUBSCRIBE_MESSAGES_COUNT_TOTAL,
-                        "x_subscription_id" => Arc::clone(&state.x_subscription_id),
+                        "x_subscription_id" => Arc::clone(&x_subscription_id),
                         "message" => message.as_str(),
                     )
                     .increment(1);
                     counter!(
                         metrics::GRPC_SUBSCRIBE_MESSAGES_BYTES_TOTAL,
-                        "x_subscription_id" => Arc::clone(&state.x_subscription_id),
+                        "x_subscription_id" => Arc::clone(&x_subscription_id),
                         "message" => message.as_str(),
                     )
                     .increment(data.len() as u64);
-
                     Ok(data)
                 }
                 Err(error) => Err(error),
             };
-            drop(state);
+            this.drain.push_back(item);
+        }
+        drop(state);
 
-            self.finished = item.is_err();
+        // Serve first item from freshly drained buffer.
+        if let Some(item) = this.drain.pop_front() {
+            this.finished = item.is_err();
             Poll::Ready(Some(item))
         } else {
             Poll::Pending

--- a/richat/src/grpc/server.rs
+++ b/richat/src/grpc/server.rs
@@ -11,6 +11,7 @@ use {
     futures::{
         future::{FutureExt, TryFutureExt, ready, try_join_all},
         stream::Stream,
+        task::AtomicWaker,
     },
     prost::Message,
     quanta::Instant,
@@ -377,6 +378,8 @@ impl GrpcServer {
                     }
                 }
             }
+            let has_pending = !state.messages.is_empty();
+
             if messages_counter == 0 {
                 ticks_without_messages += 1;
             } else {
@@ -386,7 +389,19 @@ impl GrpcServer {
                 ticks_without_messages = 0;
             }
             drop(state);
-            if !errored {
+
+            // Wake poll_next so it can drain via try_lock.
+            // Yield briefly only when the client has buffered messages,
+            // so poll_next (on a tokio thread) can win the lock against
+            // pinned worker threads that would otherwise re-acquire instantly.
+            if messages_counter > 0 || has_pending {
+                client.drain_waker.wake();
+                sleep(Duration::from_millis(1));
+            }
+
+            if errored {
+                client.drain_waker.wake();
+            } else {
                 prev_client = Some(client);
             }
 
@@ -748,6 +763,7 @@ impl geyser_gen::geyser_server::Geyser for GrpcServer {
 #[derive(Debug, Clone)]
 pub struct SubscribeClient {
     state: Arc<Mutex<SubscribeClientState>>,
+    drain_waker: Arc<AtomicWaker>,
 }
 
 impl SubscribeClient {
@@ -765,6 +781,7 @@ impl SubscribeClient {
         );
         Self {
             state: Arc::new(Mutex::new(state)),
+            drain_waker: Arc::new(AtomicWaker::new()),
         }
     }
 
@@ -931,7 +948,17 @@ impl Stream for ReceiverStream {
             return Poll::Ready(None);
         }
 
-        let mut state = self.client.state_lock();
+        let mut state = match self.client.state.try_lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                self.client.drain_waker.register(cx.waker());
+                match self.client.state.try_lock() {
+                    Ok(guard) => guard,
+                    Err(_) => return Poll::Pending,
+                }
+            }
+        };
+
         if let Some(item) = state.pop_message(cx) {
             let item = match item {
                 Ok((message, data)) => {


### PR DESCRIPTION
## Summary

- **`try_lock` + `AtomicWaker`**: `poll_next` uses `try_lock` instead of blocking `.lock()`, preventing tokio worker threads from being parked on the mutex. An `AtomicWaker` ensures the stream is re-polled after the worker releases the lock.
- **Drain buffer**: Instead of returning one message per `poll_next` call (re-acquiring the mutex each time), drain ALL available messages into a per-stream `VecDeque` in a single lock acquisition. Subsequent `poll_next` calls serve from the local buffer with zero contention.
- **Remove 1ms worker sleep**: The drain buffer makes contention minimal, so the worker no longer needs to yield for `poll_next` to win the lock.

## Context

Subscribers were experiencing periodic 5-10 second stalls on gRPC streams. The root cause was mutex contention between the pinned worker thread (which holds the lock while pushing messages) and tokio-polled `poll_next` (which needs the lock to read messages). The worker's tight loop would re-acquire the lock instantly after releasing it, starving `poll_next`.

## Test plan

- [x] Deployed to richat-dal-frontend-2 and verified flow control pauses stopped climbing
- [x] Verified delivery_rate remains stable under load
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)