### PR TITLE
Add channel_first_available_slot metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## 2026-03-17
 
+- richat-v8.2.3
+
+### Fixes
+
+- richat: expose first available slot in metrics ([#202](https://github.com/lamports-dev/richat/pull/202))
+
+## 2026-03-17
+
 - richat-v8.2.2
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "richat"
-version = "8.2.2"
+version = "8.2.3"
 dependencies = [
  "affinity-linux",
  "agave-reserved-account-keys",

--- a/richat/Cargo.toml
+++ b/richat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "richat"
-version = "8.2.2"
+version = "8.2.3"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Richat App"

--- a/richat/src/channel.rs
+++ b/richat/src/channel.rs
@@ -230,6 +230,21 @@ pub enum IndexLocation {
     Memory(u64),
 }
 
+fn first_available_slot(
+    replay: Option<&BTreeMap<Slot, ReplayInfo>>,
+    shared: &SharedChannel,
+) -> Option<Slot> {
+    let slot_replay = replay.and_then(|r| r.first_key_value().map(|(&slot, _)| slot));
+    let slot_processed = shared
+        .slots_lock()
+        .first_key_value()
+        .map(|(&slot, _)| slot);
+    match (slot_replay, slot_processed) {
+        (Some(r), Some(p)) => Some(r.min(p)),
+        _ => slot_replay.or(slot_processed),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Messages {
     shared_processed: Arc<SharedChannel>,
@@ -421,22 +436,8 @@ impl Messages {
     }
 
     pub fn get_first_available_slot(&self) -> Option<Slot> {
-        let slot_replay = self
-            .replay_info
-            .as_deref()
-            .map(mutex_lock)
-            .and_then(|replay| replay.first_key_value().map(|(slot, _info)| *slot));
-
-        let slot_processed = self
-            .shared_processed
-            .slots_lock()
-            .first_key_value()
-            .map(|(slot, _head)| *slot);
-
-        match (slot_replay, slot_processed) {
-            (Some(slot_replay), Some(slot_processed)) => Some(slot_replay.min(slot_processed)),
-            _ => slot_replay.or(slot_processed),
-        }
+        let replay_guard = self.replay_info.as_deref().map(mutex_lock);
+        first_available_slot(replay_guard.as_deref(), &self.shared_processed)
     }
 
     pub fn replay_from_storage(
@@ -644,13 +645,7 @@ impl Sender {
                             .set(msg.slot() as f64)
                     }
                     if msg.status() == SlotStatus::SlotProcessed {
-                        let slots = self.processed.shared.slots_lock();
-                        let processed_slots_len = slots.len();
-
-                        if let Some((&first, _)) = slots.first_key_value() {
-                            gauge!(metrics::CHANNEL_FIRST_AVAILABLE_SLOT).set(first as f64);
-                        }
-                        drop(slots);
+                        let processed_slots_len = self.processed.shared.slots_lock().len();
 
                         debug!(
                             "new processed {slot} / {} messages / {} slots / {} bytes",
@@ -762,6 +757,10 @@ impl Sender {
         }
         if replay_inserted || clean_after_finalized {
             gauge!(metrics::CHANNEL_STORAGE_SLOTS_TOTAL).set(replay_lock.len() as f64);
+
+            if let Some(slot) = first_available_slot(Some(&replay_lock), &self.processed.shared) {
+                gauge!(metrics::CHANNEL_FIRST_AVAILABLE_SLOT).set(slot as f64);
+            }
         }
 
         if let Some(mut wakers) = self.processed.shared.wakers_lock() {

--- a/richat/src/channel.rs
+++ b/richat/src/channel.rs
@@ -643,7 +643,6 @@ impl Sender {
                     }
                     if msg.status() == SlotStatus::SlotProcessed {
                         let processed_slots_len = self.processed.shared.slots_lock().len();
-
                         debug!(
                             "new processed {slot} / {} messages / {} slots / {} bytes",
                             self.processed.tail - self.processed.head,

--- a/richat/src/channel.rs
+++ b/richat/src/channel.rs
@@ -644,7 +644,14 @@ impl Sender {
                             .set(msg.slot() as f64)
                     }
                     if msg.status() == SlotStatus::SlotProcessed {
-                        let processed_slots_len = self.processed.shared.slots_lock().len();
+                        let slots = self.processed.shared.slots_lock();
+                        let processed_slots_len = slots.len();
+
+                        if let Some((&first, _)) = slots.first_key_value() {
+                            gauge!(metrics::CHANNEL_FIRST_AVAILABLE_SLOT).set(first as f64);
+                        }
+                        drop(slots);
+
                         debug!(
                             "new processed {slot} / {} messages / {} slots / {} bytes",
                             self.processed.tail - self.processed.head,

--- a/richat/src/channel.rs
+++ b/richat/src/channel.rs
@@ -235,10 +235,7 @@ fn first_available_slot(
     shared: &SharedChannel,
 ) -> Option<Slot> {
     let slot_replay = replay.and_then(|r| r.first_key_value().map(|(&slot, _)| slot));
-    let slot_processed = shared
-        .slots_lock()
-        .first_key_value()
-        .map(|(&slot, _)| slot);
+    let slot_processed = shared.slots_lock().first_key_value().map(|(&slot, _)| slot);
     match (slot_replay, slot_processed) {
         (Some(r), Some(p)) => Some(r.min(p)),
         _ => slot_replay.or(slot_processed),

--- a/richat/src/metrics.rs
+++ b/richat/src/metrics.rs
@@ -23,6 +23,7 @@ use {
 pub const BLOCK_MESSAGE_FAILED: &str = "block_message_failed"; // reason
 pub const CHANNEL_EVENTS_RECEIVED: &str = "channel_events_received"; // source, type
 pub const CHANNEL_SLOT: &str = "channel_slot"; // commitment
+pub const CHANNEL_FIRST_AVAILABLE_SLOT: &str = "channel_first_available_slot";
 pub const CHANNEL_MESSAGES_TOTAL: &str = "channel_messages_total";
 pub const CHANNEL_SLOTS_TOTAL: &str = "channel_slots_total";
 pub const CHANNEL_BYTES_TOTAL: &str = "channel_bytes_total";
@@ -68,6 +69,7 @@ pub fn setup() -> Result<PrometheusHandle, BuildError> {
     describe_counter!(BLOCK_MESSAGE_FAILED, "Block message reconstruction errors");
     describe_counter!(CHANNEL_EVENTS_RECEIVED, "Total number of received messages by source");
     describe_gauge!(CHANNEL_SLOT, "Latest slot in channel by commitment");
+    describe_gauge!(CHANNEL_FIRST_AVAILABLE_SLOT, "First available slot for replay");
     describe_gauge!(CHANNEL_MESSAGES_TOTAL, "Total number of messages in channel");
     describe_gauge!(CHANNEL_SLOTS_TOTAL, "Total number of slots in channel");
     describe_gauge!(CHANNEL_BYTES_TOTAL, "Total size of all messages in channel");


### PR DESCRIPTION
## Summary

- Adds `channel_first_available_slot` Prometheus gauge — emitted on each processed slot alongside existing channel metrics
- Reads from the BTreeMap's first key (O(1)) while the slots lock is already held for `CHANNEL_SLOTS_TOTAL`

## Context

When clients get "failed to get replay position for slot X" errors, there's currently no metric to see what the actual available range is without calling the `subscribe_replay_info` gRPC endpoint.

## Test plan

- [ ] Verify metric appears in `/metrics` endpoint after deployment
- [ ] Add to Grafana dashboard alongside `channel_slot` to show the replay window

🤖 Generated with [Claude Code](https://claude.com/claude-code)