### PR TITLE
richat: fix pubsub panic on client disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2026-04-06
+
+- richat-v9.0.1
+
+### Fixes
+
+- richat: fix client removal in pubsub ([#204](https://github.com/lamports-dev/richat/pull/204))
+
 ## 2026-04-04
 
 - richat-v9.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "richat"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "affinity-linux",
  "agave-reserved-account-keys",

--- a/richat/Cargo.toml
+++ b/richat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "richat"
-version = "9.0.0"
+version = "9.0.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Richat App"

--- a/richat/src/pubsub/tracker.rs
+++ b/richat/src/pubsub/tracker.rs
@@ -853,10 +853,7 @@ impl SlotTransactionStatsItem {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        tokio::sync::broadcast,
-    };
+    use {super::*, tokio::sync::broadcast};
 
     fn create_test_deps() -> (CachedSignatures, RpcNotifications) {
         let signatures = CachedSignatures::new(100, 100);

--- a/richat/src/pubsub/tracker.rs
+++ b/richat/src/pubsub/tracker.rs
@@ -195,7 +195,7 @@ impl Subscriptions {
                                 id: subscription_id,
                                 config_hash,
                                 config,
-                                clients: HashSet::new(),
+                                clients: HashSet::from([client_id]),
                             },
                         );
                 }
@@ -848,5 +848,57 @@ impl SlotTransactionStatsItem {
             return Some((ParsedMessage::Slot(Arc::new(message)), stats));
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        tokio::sync::broadcast,
+    };
+
+    fn create_test_deps() -> (CachedSignatures, RpcNotifications) {
+        let signatures = CachedSignatures::new(100, 100);
+        let (sender, _) = broadcast::channel(16);
+        let notifications = RpcNotifications::new(16, 1024, sender);
+        (signatures, notifications)
+    }
+
+    #[test]
+    fn test_subscribe_new_config_inserts_client_id() {
+        let mut subscriptions = Subscriptions::default();
+        let (mut signatures, mut notifications) = create_test_deps();
+
+        let client_id = 1;
+        let config = SubscribeConfig::Slot;
+        let subscription_id =
+            subscriptions.subscribe(client_id, config, &mut signatures, &mut notifications);
+
+        // Verify client_id is in the subscription's clients set
+        let info = subscriptions
+            .subscriptions_per_method
+            .get(&(CommitmentLevel::Processed, SubscribeMethod::Slot))
+            .unwrap()
+            .get(&subscription_id)
+            .unwrap();
+        assert!(info.clients.contains(&client_id));
+    }
+
+    #[test]
+    fn test_remove_client_after_new_subscription_does_not_panic() {
+        let mut subscriptions = Subscriptions::default();
+        let (mut signatures, mut notifications) = create_test_deps();
+
+        let client_id = 1;
+        let config = SubscribeConfig::Slot;
+        subscriptions.subscribe(client_id, config, &mut signatures, &mut notifications);
+
+        // This used to panic because client_id was missing from the clients set
+        subscriptions.remove_client(client_id);
+
+        // Subscription should be fully cleaned up
+        assert!(subscriptions.subscriptions_per_client.is_empty());
+        assert!(subscriptions.subscriptions.is_empty());
     }
 }


### PR DESCRIPTION
New subscriptions (Vacant branch) were created with an empty clients set, so the subscribing client_id was never tracked. When that client disconnected, remove_client_subscription hit an assert on the missing client_id and panicked. Initialize the set with the subscribing client_id to match the Occupied branch behavior.