### PR TITLE
Subscribe to entries for subscribe_accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ## 2026-04-16
 
-### Features
-
 - richat-v9.1.0
+
+### Features
 
 - richat: add entries to subscribe_accounts subscription ([#205](https://github.com/lamports-dev/richat/pull/205))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
+## 2026-04-16
+
+### Features
+
+- richat-v9.1.0
+
+- richat: add entries to subscribe_accounts subscription ([#205](https://github.com/lamports-dev/richat/pull/205))
+
 ## 2026-04-06
 
 - richat-v9.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -2222,7 +2222,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2701,7 +2701,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2962,7 +2962,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3017,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3663,9 +3663,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5881,7 +5881,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "richat"
-version = "9.0.1"
+version = "9.1.0"
 dependencies = [
  "affinity-linux",
  "agave-reserved-account-keys",

--- a/deny.toml
+++ b/deny.toml
@@ -4,12 +4,18 @@ all-features = true
 [advisories]
 ignore = [
     # Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0134
+    # rustls-pemfile 2.2.0 registry+https://github.com/rust-lang/crates.io-index
     "RUSTSEC-2025-0134",
 
     # Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141
+    # bincode 1.3.3 registry+https://github.com/rust-lang/crates.io-index
     "RUSTSEC-2025-0141",
 
     # Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0009
     # time 0.3.41 registry+https://github.com/rust-lang/crates.io-index
     "RUSTSEC-2026-0009",
+
+    # Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0097
+    # rand 0.8.5 registry+https://github.com/rust-lang/crates.io-index
+    "RUSTSEC-2026-0097",
 ]

--- a/richat/Cargo.toml
+++ b/richat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "richat"
-version = "9.0.1"
+version = "9.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Richat App"

--- a/richat/src/grpc/server.rs
+++ b/richat/src/grpc/server.rs
@@ -621,6 +621,7 @@ impl geyser_gen::geyser_server::Geyser for GrpcServer {
                             .into_iter()
                             .collect(),
                             blocks_meta: ["".to_owned()].into_iter().collect(),
+                            entries: ["".to_owned()].into_iter().collect(),
                             ..Default::default()
                         };
                         limits


### PR DESCRIPTION
## Changes
- `subscribe_accounts` extends the base subscription to also include slots and block meta. At Jupiter we are looking to use https://github.com/rpcpool/yellowstone-block-machine to detect forks and dead slots which also leverages entries.