### PR TITLE
Remove entries from subscribe_accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Breaking
 
-## 2026-04-16
+## 2026-04-30
 
-- richat-v9.1.0
+- richat-v10.0.0
 
 ### Breaking
 
-- richat: remove entries to subscribe_accounts subscription ([#210](https://github.com/lamports-dev/richat/pull/210))
+- richat: remove entries from subscribe_accounts subscription ([#210](https://github.com/lamports-dev/richat/pull/210))
 
 ## 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 - richat-v9.1.0
 
+### Breaking
+
+- richat: remove entries to subscribe_accounts subscription ([#210](https://github.com/lamports-dev/richat/pull/210))
+
+## 2026-04-16
+
+- richat-v9.1.0
+
 ### Features
 
 - richat: add entries to subscribe_accounts subscription ([#205](https://github.com/lamports-dev/richat/pull/205))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "richat"
-version = "9.1.0"
+version = "9.1.1"
 dependencies = [
  "affinity-linux",
  "agave-reserved-account-keys",
@@ -3663,9 +3663,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "richat"
-version = "9.1.1"
+version = "10.0.0"
 dependencies = [
  "affinity-linux",
  "agave-reserved-account-keys",

--- a/richat/Cargo.toml
+++ b/richat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "richat"
-version = "9.1.1"
+version = "10.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Richat App"

--- a/richat/Cargo.toml
+++ b/richat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "richat"
-version = "9.1.0"
+version = "9.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 description = "Richat App"

--- a/richat/src/grpc/server.rs
+++ b/richat/src/grpc/server.rs
@@ -621,7 +621,6 @@ impl geyser_gen::geyser_server::Geyser for GrpcServer {
                             .into_iter()
                             .collect(),
                             blocks_meta: ["".to_owned()].into_iter().collect(),
-                            entries: ["".to_owned()].into_iter().collect(),
                             ..Default::default()
                         };
                         limits


### PR DESCRIPTION
## Changes
- Remove entries from subscribe accounts which was originally added by #205 for detecting forks but is not needed for fork detection